### PR TITLE
Use BadRequest from werkzeug instead of flask

### DIFF
--- a/octoprint_GPX/__init__.py
+++ b/octoprint_GPX/__init__.py
@@ -7,7 +7,7 @@ from collections import OrderedDict
 
 import flask
 from flask import request, make_response
-from flask.exceptions import BadRequest
+from werkzeug.exceptions import BadRequest
 
 import octoprint.plugin
 from octoprint.events import Events


### PR DESCRIPTION
Reason is that flask.exceptions is gone for Flask > 0.10 (compare
foosel/OctoPrint#870) and OctoPrint's Flask dependency allows
Flask 0.10 to be installed.

See also error log in #3 where this also occurs.
