### PR TITLE
Add missing GPX machine types.

### DIFF
--- a/octoprint_GPX/templates/GPX_settings.jinja2
+++ b/octoprint_GPX/templates/GPX_settings.jinja2
@@ -38,6 +38,7 @@
                     <option value="fcp">{{ _('FlashForge Creator Pro') }}</option>
                     <option value="t6">{{ _('TOM Mk6 - single extruder') }}</option>
                     <option value="t7">{{ _('TOM Mk7 - single extruder') }}</option>
+                    <option value="t7d">{{ _('TOM Mk7 - dual extruder') }}</option>
                     <option value="r1">{{ _('Replicator 1 - single extruder') }}</option>
                     <option value="r1d">{{ _('Replicator 1 - dual extruder') }}</option>
                     <option value="r2">{{ _('Replicator 2 (default)') }}</option>
@@ -45,6 +46,7 @@
                     <option value="r2x">{{ _('Replicator 2X') }}</option>
                     <option value="z">{{ _('ZYYX - single extruder') }}</option>
                     <option value="zd">{{ _('ZYYX - dual extruder') }}</option>
+                    <option value="zp">{{ _('ZYYX pro') }}</option>
                 </select>
                 <button class="btn" data-bind="click: showMachineDialog">{{ _('Edit Machine Definition...') }}</button>
             </div>


### PR DESCRIPTION
Hi!

The settings drop-down is missing two machines that exist in GPX. This patch adds them.

Cheers,
Fredrik