### PR TITLE
FIX: OSError which would cause printer to disconnect

### DIFF
--- a/octoprint_GPX/gpxprinter.py
+++ b/octoprint_GPX/gpxprinter.py
@@ -133,6 +133,7 @@ class GpxPrinter():
 				# loop sending until the queue isn't full
 				timeout_retries = 0
 				bo_retries = 0
+				write_retries = 0
 				while True:
 					try:
 						self._append(gpx.write(data))
@@ -152,6 +153,11 @@ class GpxPrinter():
 						timeout_retries += 1
 						if (timeout_retries >= 5):
 							raise
+					except OSError:
+						write_retries += 1
+						if (write_retries >= 5):
+							raise
+						time.sleep(0.1) # 100 ms
 
 			finally:
 				if match is None:


### PR DESCRIPTION
Fix for #93 and #95

OctoPrint-GPX throws an OSError on write that causes OctoPrint to disconnect from the printer in the middle of a print. For me it would occur within the first 10-15 seconds of a print. This fix retries the write 5 times before throwing the exception